### PR TITLE
Tw history

### DIFF
--- a/Backend/findyourngo/restapi/controllers/rating_controller.py
+++ b/Backend/findyourngo/restapi/controllers/rating_controller.py
@@ -96,7 +96,8 @@ def generate_missing_data_points(tw_data_points):
             result.append(data_point)
 
     last_result = result[len(result)-1]
-    while datetime.today().date() > last_result.date and datetime.today().day - last_result.date.day >= 1:
+    today_date = datetime.today().date()
+    while today_date > last_result.date:
         last_result = NgoTWDataPoint(date=datetime(last_result.date.year, last_result.date.month, last_result.date.day + 1).date(), daily_tw_score=last_result.daily_tw_score)
         result.append(last_result)
     return result

--- a/Backend/findyourngo/restapi/controllers/views.py
+++ b/Backend/findyourngo/restapi/controllers/views.py
@@ -67,6 +67,11 @@ def twUpdate(request):
     return HttpResponse('TW updated with PageRank')
 
 
+def storeDailyTw(request):
+    TWUpdater().store_daily_tw()
+    return HttpResponse('Daily TW stored')
+
+
 # request is a necessary positional parameter for the framework call
 def name_list(request):
     result = list(map(lambda ngo: ngo['name'], Ngo.objects.all().order_by('name').values()))

--- a/Backend/findyourngo/restapi/models.py
+++ b/Backend/findyourngo/restapi/models.py
@@ -83,6 +83,11 @@ class NgoStats(models.Model):
     yearly_income = models.CharField(max_length=200)
 
 
+class NgoTWDataPoint(models.Model):
+    daily_tw_score = models.FloatField(validators=[MinValueValidator(TW_MIN_VALUE), MaxValueValidator(TW_MAX_VALUE)])
+    date = models.DateField()
+
+
 class NgoTWScore(models.Model):
     total_tw_score = models.FloatField(validators=[MinValueValidator(TW_MIN_VALUE), MaxValueValidator(TW_MAX_VALUE)])
     base_tw_score = models.FloatField(validators=[MinValueValidator(TW_MIN_VALUE), MaxValueValidator(TW_MAX_VALUE)])
@@ -92,6 +97,7 @@ class NgoTWScore(models.Model):
     ecosoc_score = models.FloatField(default=0)
     pagerank_score = models.FloatField(default=0, validators=[MinValueValidator(0), MaxValueValidator(PAGERANK_MAX_BOOST)])
     ngo_account_score = models.FloatField(default=0, validators=[MinValueValidator(0), MaxValueValidator(NGO_ACCOUNT_BOOST)])
+    tw_series = models.ManyToManyField(NgoTWDataPoint)
 
 
 class Ngo(models.Model):

--- a/Backend/findyourngo/restapi/tasks/background_tasks.py
+++ b/Backend/findyourngo/restapi/tasks/background_tasks.py
@@ -1,12 +1,18 @@
 from background_task import background
+from background_task.models import Task
+from datetime import datetime
 
 from findyourngo.trustworthiness_calculator.TWUpdater import TWUpdater
 from findyourngo.restapi.controllers.views import clearBackgroundTasks
+
+today_date = datetime.today()
+today_midnight = today_date.replace(hour=00, minute=00, second=1)
 
 
 def start_background_tasks():
     clearBackgroundTasks('')  # delete all background tasks from db to ensure them running only once
     run_tw_update(repeat=3600, repeat_until=None)  # hourly update
+    store_daily_tw(repeat=Task.DAILY)
 
 
 @background(schedule=300)
@@ -14,6 +20,13 @@ def run_tw_update():
     print('Recalculate TW and PageRank')
     TWUpdater().update()
     print('TW and PageRank recalculated')
+
+
+@background(schedule=today_midnight)
+def store_daily_tw():
+    print('Store daily TW')
+    TWUpdater().store()
+    print('Daily TW stored')
 
 
 # If the database isn't migrated, this will lead to a chain of errors

--- a/Backend/findyourngo/trustworthiness_calculator/TWUpdater.py
+++ b/Backend/findyourngo/trustworthiness_calculator/TWUpdater.py
@@ -1,7 +1,9 @@
-from findyourngo.restapi.models import Ngo
+from findyourngo.restapi.models import Ngo, NgoTWDataPoint
 from findyourngo.trustworthiness_calculator.Pagerank import PageRank
 from findyourngo.trustworthiness_calculator.TWCalculator import TWCalculator
 from findyourngo.trustworthiness_calculator.TWRecalculator import TWRecalculator
+
+from datetime import datetime
 
 
 class TWUpdater:
@@ -12,6 +14,19 @@ class TWUpdater:
     def update(self) -> None:
         self._calculate_tw_without_pagerank()
         self._add_pagerank()
+
+    def store(self) -> None:
+        self.update()
+        self.store_daily_tw()
+
+    def store_daily_tw(self) -> None:
+        for ngo in Ngo.objects.all():
+            ngo_tw_score = ngo.tw_score
+
+            if not ngo_tw_score.tw_series.filter(date=datetime.today()).exists():
+                daily_tw = NgoTWDataPoint.objects.create(daily_tw_score=ngo_tw_score.total_tw_score,
+                                                         date=datetime.today())
+                ngo_tw_score.tw_series.add(daily_tw)
 
     def _calculate_tw_without_pagerank(self) -> None:
         for ngo in Ngo.objects.all():

--- a/Backend/findyourngo/trustworthiness_calculator/TWUpdater.py
+++ b/Backend/findyourngo/trustworthiness_calculator/TWUpdater.py
@@ -24,9 +24,12 @@ class TWUpdater:
             ngo_tw_score = ngo.tw_score
 
             if not ngo_tw_score.tw_series.filter(date=datetime.today()).exists():
-                daily_tw = NgoTWDataPoint.objects.create(daily_tw_score=ngo_tw_score.total_tw_score,
-                                                         date=datetime.today())
-                ngo_tw_score.tw_series.add(daily_tw)
+                last_tw_entry = ngo_tw_score.tw_series.all().last()
+                if last_tw_entry is None or not last_tw_entry.daily_tw_score == ngo_tw_score.total_tw_score:
+
+                    daily_tw = NgoTWDataPoint.objects.create(daily_tw_score=ngo_tw_score.total_tw_score,
+                                                             date=datetime.today())
+                    ngo_tw_score.tw_series.add(daily_tw)
 
     def _calculate_tw_without_pagerank(self) -> None:
         for ngo in Ngo.objects.all():

--- a/Backend/findyourngo/urls.py
+++ b/Backend/findyourngo/urls.py
@@ -50,6 +50,7 @@ urlpatterns = [
     url(r'^twRating', rating_controller.tw_rating),
     url(r'^userReviewsForNgo', rating_controller.userReviews),
     url(r'^review', rating_controller.review),
+    url(r'^twHistory', rating_controller.tw_history),
     path('twUpdate', views.twUpdate),
     path('storeDailyTw', views.storeDailyTw),
     url(r'names', views.name_list),

--- a/Backend/findyourngo/urls.py
+++ b/Backend/findyourngo/urls.py
@@ -51,6 +51,7 @@ urlpatterns = [
     url(r'^userReviewsForNgo', rating_controller.userReviews),
     url(r'^review', rating_controller.review),
     path('twUpdate', views.twUpdate),
+    path('storeDailyTw', views.storeDailyTw),
     url(r'names', views.name_list),
     url('test/', views.TestView.as_view(), name='test'),
     path('connections/', connection_controller.view_connections),

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -28,6 +28,8 @@
     "@fullcalendar/list": "^5.5.0",
     "@fullcalendar/timegrid": "^5.5.1",
     "angularx-social-login": "^3.5.4",
+    "echarts": "^5.0.2",
+    "ngx-echarts": "^6.0.0",
     "rxjs": "~6.6.0",
     "tslib": "^2.0.0",
     "zone.js": "~0.10.2"
@@ -36,6 +38,7 @@
     "@angular-devkit/build-angular": "~0.1100.2",
     "@angular/cli": "~11.0.2",
     "@angular/compiler-cli": "~11.0.1",
+    "@types/echarts": "^4.9.3",
     "@types/jasmine": "~3.6.0",
     "@types/node": "^12.11.1",
     "codelyzer": "^6.0.0",
@@ -47,6 +50,7 @@
     "karma-jasmine": "~4.0.0",
     "karma-jasmine-html-reporter": "^1.5.0",
     "protractor": "~7.0.0",
+    "resize-observer-polyfill": "^1.5.1",
     "ts-node": "~8.3.0",
     "tslint": "~6.1.0",
     "typescript": "~4.0.2"

--- a/Frontend/src/app/components/ngo-rating-table/ngo-rating-table.component.scss
+++ b/Frontend/src/app/components/ngo-rating-table/ngo-rating-table.component.scss
@@ -2,7 +2,3 @@
   width: 30% !important;
   height: 12px !important;
 }
-
-.rating-table {
-  margin-top: 40px;
-}

--- a/Frontend/src/app/components/ngo-tw-history/ngo-tw-history.component.html
+++ b/Frontend/src/app/components/ngo-tw-history/ngo-tw-history.component.html
@@ -1,0 +1,1 @@
+<div echarts [options]="options" style="width: 100%; height: 100%" class="demo-chart"></div>

--- a/Frontend/src/app/components/ngo-tw-history/ngo-tw-history.component.spec.ts
+++ b/Frontend/src/app/components/ngo-tw-history/ngo-tw-history.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NgoTwHistoryComponent } from './ngo-tw-history.component';
+
+describe('NgoTwHistoryComponent', () => {
+  let component: NgoTwHistoryComponent;
+  let fixture: ComponentFixture<NgoTwHistoryComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ NgoTwHistoryComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NgoTwHistoryComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/Frontend/src/app/components/ngo-tw-history/ngo-tw-history.component.ts
+++ b/Frontend/src/app/components/ngo-tw-history/ngo-tw-history.component.ts
@@ -1,0 +1,115 @@
+import {Component, Input, OnInit} from '@angular/core';
+import {RatingService} from '../../services/rating.service';
+import {NgoTWDataPoint} from '../../models/ratings';
+import {EChartsOption} from 'echarts';
+import {DatePipe} from '@angular/common';
+import * as echarts from 'echarts';
+
+@Component({
+  selector: 'ngo-tw-history',
+  templateUrl: './ngo-tw-history.component.html',
+  styleUrls: ['./ngo-tw-history.component.scss'],
+  providers: [DatePipe]
+})
+export class NgoTwHistoryComponent implements OnInit {
+  @Input() ngoId: number = 1;
+  options: any;
+
+  constructor(public datePipe: DatePipe, private ratingService: RatingService) {}
+
+  ngOnInit(): void {
+    if (this.ngoId) {
+        this.ratingService.getTwHistory(this.ngoId).subscribe((dataPoints: NgoTWDataPoint[]) => {
+          this.createHistoryData(dataPoints);
+        });
+    }
+  }
+
+  createHistoryData(dataPoints: NgoTWDataPoint[]): void {
+    const data: any[] = [];
+    for (const dataPoint of dataPoints) {
+      data.push([new Date(dataPoint.date), dataPoint.dailyTwScore]);
+    }
+    this.createChartOptions(data);
+  }
+
+  createChartOptions(data: any[]): void {
+    this.options = {
+      grid: {
+        top: 10,
+        right: 10,
+        bottom: 0,
+        left: 0,
+        containLabel: true
+      },
+      xAxis: {
+        type: 'time',
+        axisLine: {
+          show: false
+        },
+        axisTick: {
+          show: false
+        },
+        minInterval: 3600 * 1000 * 24,
+        axisLabel: {
+          formatter: (params: any) => {
+            return this.datePipe.transform(new Date(params), 'MMM d');
+          },
+          showMinLabel: true,
+          showMaxLabel: false,
+          fontSize: 10
+        }
+      },
+      yAxis: {
+        type: 'value',
+        min: 0,
+        max: 5,
+        interval: 1,
+        axisLabel: {
+          showMinLabel: true,
+          showMaxLabel: true,
+          fontSize: 10
+        },
+        axisTick: {
+          show: false
+        }
+      },
+      tooltip: {
+        borderColor: '#424242',
+        textStyle: {
+          color: '#424242'
+        },
+        trigger: 'axis',
+        axisPointer: {
+            animation: false
+        }
+      },
+      series: [
+        {
+          name: 'TW value:',
+          data: data,
+          type: 'line',
+          smooth: true,
+          symbol: 'circle',
+          itemStyle: {
+            color: '#c62828'
+          },
+          areaStyle: {
+            color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [{
+              offset: 0,
+              color: '#c62828'
+            }, {
+              offset: 0.75,
+              color: '#ffc107'
+            }, {
+              offset: 1,
+              color: '#ffffff'
+            }])
+          },
+        }
+      ]
+    };
+  }
+
+
+}

--- a/Frontend/src/app/components/ngo-tw-rating/ngo-tw-rating.component.html
+++ b/Frontend/src/app/components/ngo-tw-rating/ngo-tw-rating.component.html
@@ -1,14 +1,16 @@
 <div class="rating-overview" fxLayout="row wrap">
 
-  <div class="tw-rating" fxFlex="33%" fxFlex.sm="33%"
+  <div class="tw-rating"
        fxFlex.xs="100%">
     <div class="rating">
       <star-rating [value]="totalTrustworthiness - 1" [editable]="false"></star-rating>
       <mat-icon class="info-icon" (click)="showInformation()">info</mat-icon>
     </div>
 
-    <ngo-rating-table [reviewNumberIndexedByRating]="reviewNumberIndexedByRating"
-                      [totalReviewNumber]="totalReviewNumber"
-    ></ngo-rating-table>
+    <div class="stats">
+      <ngo-rating-table [reviewNumberIndexedByRating]="reviewNumberIndexedByRating"
+                        [totalReviewNumber]="totalReviewNumber"></ngo-rating-table>
+      <ngo-tw-history [ngoId]="ngoId"></ngo-tw-history>
+    </div>
   </div>
 </div>

--- a/Frontend/src/app/components/ngo-tw-rating/ngo-tw-rating.component.scss
+++ b/Frontend/src/app/components/ngo-tw-rating/ngo-tw-rating.component.scss
@@ -1,6 +1,7 @@
 .tw-rating {
+  width: 100%;
   margin-top: 10px;
-  margin-bottom: 30px;
+  margin-bottom: 32px;
 }
 
 .rating-header {
@@ -16,4 +17,18 @@
 .rating {
   display: flex;
   flex-direction: row;
+  margin-bottom: 32px;
+}
+
+.stats {
+  display: flex;
+  justify-content: space-around;
+
+  ngo-rating-table {
+    width: 35%;
+  }
+
+  ngo-tw-history {
+    width: 55%;
+  }
 }

--- a/Frontend/src/app/models/ratings.ts
+++ b/Frontend/src/app/models/ratings.ts
@@ -30,6 +30,11 @@ export interface NewTwReview {
   text: string;
 }
 
+export interface NgoTWDataPoint {
+  dailyTwScore: number;
+  date: Date;
+}
+
 export const EMPTY_TW_REVIEWS: TwReviews = {
   reviews: [],
   reviewNumber: 0

--- a/Frontend/src/app/services/rating.service.ts
+++ b/Frontend/src/app/services/rating.service.ts
@@ -1,7 +1,7 @@
 import {Injectable} from '@angular/core';
 import {ApiService} from './api.service';
 import {Observable} from 'rxjs';
-import {NewTwReview, TwRating, TwReview, TwReviews} from '../models/ratings';
+import {NewTwReview, NgoTWDataPoint, TwRating, TwReview, TwReviews} from '../models/ratings';
 
 @Injectable({
   providedIn: 'root'
@@ -33,5 +33,9 @@ export class RatingService {
 
   getUserHasWrittenReviewForNgo(ngoId: number, userId: number): Observable<boolean> {
     return this.apiService.get('userReviewPresent', {ngoId: ngoId, userId: userId});
+  }
+
+  getTwHistory(ngoId: number): Observable<NgoTWDataPoint[]> {
+    return this.apiService.get('twHistory', {ngoId: ngoId});
   }
 }

--- a/Frontend/src/app/shared.module.ts
+++ b/Frontend/src/app/shared.module.ts
@@ -59,6 +59,8 @@ import {CalendarComponent} from './components/calendar/calendar.component';
 import {NgoEventOverviewComponent} from './components/ngo-event-overview/ngo-event-overview.component';
 import {UserOptionsComponent} from './components/user-options/user-options.component';
 import { AboutComponent } from './screens/about/about.component';
+import { NgoTwHistoryComponent } from './components/ngo-tw-history/ngo-tw-history.component';
+import {NgxEchartsModule} from 'ngx-echarts';
 
 FullCalendarModule.registerPlugins([ // register FullCalendar plugins
   dayGridPlugin,
@@ -93,7 +95,8 @@ FullCalendarModule.registerPlugins([ // register FullCalendar plugins
     AppRoutingModule,
     MatAutocompleteModule,
     FullCalendarModule,
-    MatTooltipModule
+    MatTooltipModule,
+    NgxEchartsModule.forRoot({echarts: () => import('echarts')}),
   ],
   declarations: [
     OverviewScreenComponent,
@@ -121,6 +124,7 @@ FullCalendarModule.registerPlugins([ // register FullCalendar plugins
     NgoEventOverviewComponent,
     UserOptionsComponent,
     AboutComponent,
+    NgoTwHistoryComponent,
   ],
   exports: [
     MatTabsModule,


### PR DESCRIPTION
Closes #132.

TW history chart is now displayed next to tw table.
![image](https://user-images.githubusercontent.com/57753393/108269558-75b3f000-716e-11eb-906a-44dcd33b035d.png)

The history data points are calculated in a daily background task at midnight. To trigger the calculation manually, use the storeDailyTw endpoint. Only 'new' datapoints (meaning those that contain a tw value change) are stored in a NGO's history. The remaining daily values are created onRequest.